### PR TITLE
card #62: added a mailto for the info mailbox

### DIFF
--- a/web/flipped/common/templates/common/incl_bottom.html
+++ b/web/flipped/common/templates/common/incl_bottom.html
@@ -8,16 +8,16 @@
                 <div class="span4">
                     <h3>מי אנחנו?</h3>
                     <p>מתנדבי "שיעור פתוח" פועלים במסגרת
-                    <a href="http://wiki.hasadna.org.il/index.php?title=%D7%A2%D7%9E%D7%95%D7%93_%D7%A8%D7%90%D7%A9%D7%99">הסדנא לידע ציבורי</a>
-                . האתר בנוי בקוד פתוח, נטול אינטרסים מסחריים ויהיה חינם לצמיתות.
+                    <a href="http://wiki.hasadna.org.il/index.php?title=%D7%A2%D7%9E%D7%95%D7%93_%D7%A8%D7%90%D7%A9%D7%99">הסדנא לידע ציבורי</a>.
+                    האתר בנוי בקוד פתוח, נטול אינטרסים מסחריים ויהיה חינם לצמיתות.
                     </p>
+                    <a href="mailto:info@the-openclass.org">צור קשר</a>
                 </div>
 
                 <div class="span4">
                     <h3>רוצה לעזור?</h3>
                     <p>
-                        אתם מוזמנים להעלות סרטונים, לדרג את התוכן, ולעזור לנו לפתח את הקוד של האתר ב
-                        <a href="https://github.com/adamatan/flip_classroom_hackathon">גיטהאב</a>
+                        אתם מוזמנים להעלות סרטונים, לדרג את התוכן, ולעזור לנו לפתח את הקוד של האתר ב<a href="https://github.com/adamatan/flip_classroom_hackathon">גיטהאב</a>.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Added a very basic mailto element; minor other touches to punctuation.

This may be enough for the launch, but we can also create a mailing form, if you're into that. Either just for populating fields in the mailto link or for sending it ourselves server-side using with something like [pyramid_mailer](http://docs.pylonsproject.org/projects/pyramid_mailer/en/latest/). I've had some experience with pyramid_mailer and it works quite well, but obviously requires moving parts (coordinating with the smtp server) and can be a slight hassle particularly if we want to support file uploads.
